### PR TITLE
Fix RewardInvest available_units

### DIFF
--- a/goteoapi/models/reward.py
+++ b/goteoapi/models/reward.py
@@ -28,9 +28,13 @@ class RewardInvest(db.Model):
     @hybrid_method
     @cacher
     def reward_available_units(self, reward_id):
+        from goteoapi.invests.models import Invest
+
         """Number of available units of a reward"""
         filters = [(self.reward_id == reward_id)]
+        filters.append(Invest.status.in_(Invest.VALID_INVESTS))
         total = db.session.query(func.count(self.invest_id)) \
+                      .join(Invest, Invest.id == self.invest_id) \
                       .filter(*filters).scalar()
         if total is None:
             total = 0


### PR DESCRIPTION
This PR will fix the available_units function. Currently it does not check for the status of the invests, therefore the total units of the reward will not be correct if someone has started an invest with that reward but it doens't have a valid status.

The query has changed to join it with the Invest table and take the statuses into account.